### PR TITLE
fix(INA-1987): address Trusted Advisor recommendation to not specify broad KMS permission in inline policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,8 +109,9 @@ No modules.
 | Name | Type |
 |------|------|
 | [aws_eip.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eip) | resource |
+| [aws_iam_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
-| [aws_iam_role_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy_attachment.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_mwaa_environment.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/mwaa_environment) | resource |
 | [aws_nat_gateway.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/nat_gateway) | resource |
 | [aws_route_table.private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table) | resource |

--- a/iam.tf
+++ b/iam.tf
@@ -4,10 +4,15 @@ resource "aws_iam_role" "this" {
   tags               = var.tags
 }
 
-resource "aws_iam_role_policy" "this" {
+resource "aws_iam_policy" "this" {
   name   = "mwaa-${var.environment_name}-execution-policy"
   policy = data.aws_iam_policy_document.this.json
-  role   = aws_iam_role.this.id
+  tags = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "this" {
+  role = aws_iam_role.this.name
+  policy_arn = aws_iam_policy.this.arn
 }
 
 data "aws_iam_policy_document" "assume" {


### PR DESCRIPTION
Try to use a managed policy with role-policy-attachment instead.

Cannot follow the instructions here https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#kms-2-remediation as KMS policy statement uses not_resources to grant KMS permissions for any KMS keys EXCEPT account specific keys. We do not know which specific keys to narrow to.