### PR TITLE
feat(INA-1987): use customer managed KMS key for MWAA

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -4,15 +4,10 @@ resource "aws_iam_role" "this" {
   tags               = var.tags
 }
 
-resource "aws_iam_policy" "this" {
+resource "aws_iam_role_policy" "this" {
   name   = "mwaa-${var.environment_name}-execution-policy"
   policy = data.aws_iam_policy_document.this.json
-  tags = var.tags
-}
-
-resource "aws_iam_role_policy_attachment" "this" {
-  role = aws_iam_role.this.name
-  policy_arn = aws_iam_policy.this.arn
+  role   = aws_iam_role.this.id
 }
 
 data "aws_iam_policy_document" "assume" {


### PR DESCRIPTION
- The original fix (using a managed instead of an inline policy) did not help with the Trusted Advisor Recommendation - we merely got two new ones recommending not to grant broad KMS permissions in managed policies and another one about not granting any "*" permissions to services. 
- So we revert to using an inline policy ... (done)
- ... and try to replace the KMS key by a private one (TODO) => it should also be possible to pass a KMS key ARN of an existing key. 
- 