### PR TITLE
feat: Add nat gateway ips in the module output

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ No modules.
 | Name | Description |
 |------|-------------|
 | <a name="output_mwaa_arn"></a> [mwaa\_arn](#output\_mwaa\_arn) | n/a |
+| <a name="output_mwaa_nat_gateway_public_ips"></a> [mwaa\_nat\_gateway\_public\_ips](#output\_mwaa\_nat\_gateway\_public\_ips) | List of the ips of the nat gateways created by this module. |
 
 <!--- END_TF_DOCS --->
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,6 +3,6 @@ output "mwaa_arn" {
 }
 
 output "mwaa_nat_gateway_public_ips" {
-  value = var.create_networking_config ? [ for nat_gateway in aws_nat_gateway.this: nat_gateway.public_ip ]: []
+  value = aws_nat_gateway.this[*].public_ip
   description = "List of the ips of the nat gateways created by this module."
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,6 +3,6 @@ output "mwaa_arn" {
 }
 
 output "mwaa_nat_gateway_public_ips" {
-  value = [ for nat_gateway in aws_nat_gateway.this: nat_gateway.public_ip ]
+  value = var.create_networking_config ? [ for nat_gateway in aws_nat_gateway.this: nat_gateway.public_ip ]: []
   description = "List of the ips of the nat gateways created by this module."
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,8 @@
 output "mwaa_arn" {
   value = aws_mwaa_environment.this.arn
 }
+
+output "mwaa_nat_gateway_public_ips" {
+  value = [ for nat_gateway in aws_nat_gateway.this: nat_gateway.public_ip ]
+  description = "List of the ips of the nat gateways created by this module."
+}


### PR DESCRIPTION
## Description

This adds the public ips of the nat gateways created to the output of the module, which can be used somewhere else in the terraform config like setting up ingress rules.