### PR TITLE
feat: Provide output for the webserver URL of the MWAA Environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,4 +175,5 @@ No modules.
 |------|-------------|
 | <a name="output_mwaa_arn"></a> [mwaa\_arn](#output\_mwaa\_arn) | The arn of the created MWAA environment. |
 | <a name="output_mwaa_nat_gateway_public_ips"></a> [mwaa\_nat\_gateway\_public\_ips](#output\_mwaa\_nat\_gateway\_public\_ips) | List of the ips of the nat gateways created by this module. |
+| <a name="output_mwaa_webserver_url"></a> [mwaa\_webserver\_url](#output\_mwaa\_webserver\_url) | The webserver URL of the MWAA Environment. |
 <!-- END_TF_DOCS -->

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,9 +1,14 @@
 output "mwaa_arn" {
-  value = aws_mwaa_environment.this.arn
+  value       = aws_mwaa_environment.this.arn
   description = "The arn of the created MWAA environment."
 }
 
 output "mwaa_nat_gateway_public_ips" {
-  value = aws_nat_gateway.this[*].public_ip
+  value       = aws_nat_gateway.this[*].public_ip
   description = "List of the ips of the nat gateways created by this module."
+}
+
+output "mwaa_webserver_url" {
+  value       = aws_mwaa_environment.this.webserver_url
+  description = "The webserver URL of the MWAA Environment."
 }


### PR DESCRIPTION
These changes provide a `mwaa_webserver_url` output. 
Closes #87