### PR TITLE
fix: get availability zone from data source

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ No modules.
 | [aws_security_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_subnet.private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
 | [aws_subnet.public](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
+| [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
 | [aws_iam_policy_document.assume](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.base](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |

--- a/vpc.tf
+++ b/vpc.tf
@@ -14,7 +14,7 @@ resource "aws_subnet" "public" {
   cidr_block              = var.public_subnet_cidrs[count.index]
   vpc_id                  = var.vpc_id
   map_public_ip_on_launch = true
-  availability_zone       = count.index % 2 == 0 ? data.aws_availability_zones.available.names[0] : data.aws_availability_zones.available.names[1]
+  availability_zone       = count.index % 2 == 0 ? local.az_names[0] : local.az_names[1]
   tags                    = merge({
     Name = "mwaa-${var.environment_name}-public-subnet-${count.index}"
   }, var.tags)

--- a/vpc.tf
+++ b/vpc.tf
@@ -21,7 +21,7 @@ resource "aws_subnet" "private" {
   cidr_block              = var.private_subnet_cidrs[count.index]
   vpc_id                  = var.vpc_id
   map_public_ip_on_launch = false
-  availability_zone       = count.index % 2 == 0 ? "${data.aws_availability_zones.available.names[0]}" : "${data.aws_availability_zones.available.names[1]}"
+  availability_zone       = count.index % 2 == 0 ? data.aws_availability_zones.available.names[0] : data.aws_availability_zones.available.names[1]
   tags                    = merge({
     Name = "mwaa-${var.environment_name}-private-subnet-${count.index}"
   }, var.tags)

--- a/vpc.tf
+++ b/vpc.tf
@@ -25,7 +25,7 @@ resource "aws_subnet" "private" {
   cidr_block              = var.private_subnet_cidrs[count.index]
   vpc_id                  = var.vpc_id
   map_public_ip_on_launch = false
-  availability_zone       = count.index % 2 == 0 ? data.aws_availability_zones.available.names[0] : data.aws_availability_zones.available.names[1]
+  availability_zone       = count.index % 2 == 0 ? local.az_names[0] : local.az_names[1]
   tags                    = merge({
     Name = "mwaa-${var.environment_name}-private-subnet-${count.index}"
   }, var.tags)

--- a/vpc.tf
+++ b/vpc.tf
@@ -1,9 +1,16 @@
+data "aws_availability_zones" "available" {
+  filter {
+    name = "group-name"
+    values = [var.region]
+  }
+}
+
 resource "aws_subnet" "public" {
   count                   = var.create_networking_config ? length(var.public_subnet_cidrs) : 0
   cidr_block              = var.public_subnet_cidrs[count.index]
   vpc_id                  = var.vpc_id
   map_public_ip_on_launch = true
-  availability_zone       = count.index % 2 == 0 ? "${var.region}a" : "${var.region}b"
+  availability_zone       = count.index % 2 == 0 ? "${data.aws_availability_zones.available.names[0]}" : "${data.aws_availability_zones.available.names[1]}"
   tags                    = merge({
     Name = "mwaa-${var.environment_name}-public-subnet-${count.index}"
   }, var.tags)
@@ -14,7 +21,7 @@ resource "aws_subnet" "private" {
   cidr_block              = var.private_subnet_cidrs[count.index]
   vpc_id                  = var.vpc_id
   map_public_ip_on_launch = false
-  availability_zone       = count.index % 2 == 0 ? "${var.region}a" : "${var.region}b"
+  availability_zone       = count.index % 2 == 0 ? "${data.aws_availability_zones.available.names[0]}" : "${data.aws_availability_zones.available.names[1]}"
   tags                    = merge({
     Name = "mwaa-${var.environment_name}-private-subnet-${count.index}"
   }, var.tags)

--- a/vpc.tf
+++ b/vpc.tf
@@ -5,6 +5,10 @@ data "aws_availability_zones" "available" {
   }
 }
 
+locals {
+  az_names = sort(data.aws_availability_zones.available.names)
+}
+
 resource "aws_subnet" "public" {
   count                   = var.create_networking_config ? length(var.public_subnet_cidrs) : 0
   cidr_block              = var.public_subnet_cidrs[count.index]

--- a/vpc.tf
+++ b/vpc.tf
@@ -10,7 +10,7 @@ resource "aws_subnet" "public" {
   cidr_block              = var.public_subnet_cidrs[count.index]
   vpc_id                  = var.vpc_id
   map_public_ip_on_launch = true
-  availability_zone       = count.index % 2 == 0 ? "${data.aws_availability_zones.available.names[0]}" : "${data.aws_availability_zones.available.names[1]}"
+  availability_zone       = count.index % 2 == 0 ? data.aws_availability_zones.available.names[0] : data.aws_availability_zones.available.names[1]
   tags                    = merge({
     Name = "mwaa-${var.environment_name}-public-subnet-${count.index}"
   }, var.tags)


### PR DESCRIPTION

### What does this PR do?
When creating subnet, availability zone is hard coded. Fixed to get availability zone parameters from data source.


### Motivation
In certain region, `<region>-b` az is not available(ex `ap-northeast-1b`).


### More
- [x] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I ran `pre-commit run -a` with this PR

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->