### PR TITLE
ci(deps): move to new major version branch for semantic-release-action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,6 @@ jobs:
 
       - name: Create new release
         id: release
-        uses: cycjimmy/semantic-release-action@v3
+        uses: cycjimmy/semantic-release-action@v4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
there is no major version tagging for this repo, the v4, v3 etc. versions are refs (branches), not tags. The most recent release is also always on ref "main", but we do not want unplanned major version changes.